### PR TITLE
Taxonomy idfix

### DIFF
--- a/src/codon_usage.jl
+++ b/src/codon_usage.jl
@@ -26,7 +26,7 @@ function get_codon_usage(; species = 9606, aa=1)
     r = HTTP.get("http://www.kazusa.or.jp/codon/cgi-bin/showcodon.cgi?species=$species&aa=$aa&style=N")
     table_string = parsehtml(String(r.body)).root[2][7][1].text
     df = DataFrame()
-    for match in eachmatch(r"[AUGC]{3} [A-Z] \d\.\d\d [\d\s]\d\.\d \(\d+\)", table_string)
+    for match in eachmatch(r"[AUGC]{3} [A-Z] \d\.\d\d [\d\s]\d\.\d", table_string)
         entries = split(match.match)
         push!(df,
             (Codon = RNACodon(entries[1]), AminoAcid = AminoAcid(only(entries[2])), fraction = parse(Float64, entries[3]))

--- a/src/codon_usage.jl
+++ b/src/codon_usage.jl
@@ -20,13 +20,13 @@ Fetches the codon usage table of species from http://www.kazusa.or.jp/codon/.
     14: Flatworm Mitochondrial
     15: Blepharisma Nuclear Code
 
-Returns a DataFrame containing aminoacids, their codons and codon-fraction, but no stop codons
+Returns a DataFrame containing amino acids, their codons and codon-fraction, including stop codons
 """
 function get_codon_usage(; species = 9606, aa=1)
     r = HTTP.get("http://www.kazusa.or.jp/codon/cgi-bin/showcodon.cgi?species=$species&aa=$aa&style=N")
     table_string = parsehtml(String(r.body)).root[2][7][1].text
     df = DataFrame()
-    for match in eachmatch(r"[AUGC]{3} [A-Z] \d\.\d\d [\d\s]\d\.\d", table_string)
+    for match in eachmatch(r"[AUGC]{3} [A-Z\*] \d\.\d\d [\d\s]\d\.\d", table_string)
         entries = split(match.match)
         push!(df,
             (Codon = RNACodon(entries[1]), AminoAcid = AminoAcid(only(entries[2])), fraction = parse(Float64, entries[3]))


### PR DESCRIPTION
Fix #8
Before 'get_codon_usage' returned an emtpy DataFrame. This was fixed by altering the regular expression and now returns a 61x3 DataFrame. 
Stop codons were added, which results in a 64x3 DataFrame. 